### PR TITLE
Removing EOZ check because EOZ always fails ispartial.

### DIFF
--- a/src/lmacro.h
+++ b/src/lmacro.h
@@ -48,6 +48,8 @@ static int
 lmacro_ispartial (lua_State *L, char c)
 {
     static char key[2] = {'\0'};
+    if (c == EOZ)
+        return 0;
     key[0] = c;
     lua_getfield(L, -1, key);
     lua_insert(L, -2);


### PR DESCRIPTION
EOZ isn't a valid char and will always fail ispartial. Added check in ispartial anyway to prevent table hacking on the EOZ char.